### PR TITLE
Update of studentGrowthProjections

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,7 +11,7 @@ authors:
 - family-names: "Shang"
   given-names: "Yi"
 title: "SGP: Student Growth Percentiles & Percentile Growth Trajectories"
-version: 2.3-1.1
+version: 2.3-1.2
 doi: 10.5281/zenodo.10037891
-date-released: 2026-7-23
+date-released: 2026-7-25
 url: "https://sgp.io"

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: SGP
 Type: Package
 Title: Student Growth Percentiles & Percentile Growth Trajectories
-Version: 2.3-1.1
-Date: 2026-7-23
+Version: 2.3-1.2
+Date: 2026-7-25
 Authors@R: c(person(given=c("Damian", "W."), family="Betebenner", email="dbetebenner@nciea.org", role=c("aut", "cre"), comment=c(ORCID = "0000-0003-0476-5599")),
 		person(given=c("Adam", "R."), family="Van Iwaarden", email="avaniwaarden@nciea.org", role="aut"),
 		person(given="Ben", family="Domingue", email="ben.domingue@gmail.com", role="aut"),

--- a/R/studentGrowthProjections.R
+++ b/R/studentGrowthProjections.R
@@ -379,6 +379,10 @@ function(panel.data,	## REQUIRED
 				tmp.traj <- percentile.trajectories[tmp.indices, 1L:(2L+tmp.num.years.forward-1L), with=FALSE][,ID:=rep(unique(percentile.trajectories, by='ID')[['ID']], each=length(percentile.trajectory.values))]
 				setkey(tmp.traj, ID)
 				if (is.character(percentile.trajectory.values.max.forward.progression.years)) {
+					if (!(grep("MOVE_UP_STAY_UP", percentile.trajectory.values.max.forward.progression.years, value=TRUE) %in% names(panel.data[['Panel_Data']]))) {
+						tmp.name <- grep("MOVE_UP_STAY_UP", percentile.trajectory.values.max.forward.progression.years, value=TRUE)
+						panel.data[['Panel_Data']][, (tmp.name):=NA]
+					}
 					names.to.return <- intersect(names(panel.data[['Panel_Data']]), percentile.trajectory.values.max.forward.progression.years)
 					tmp.traj <- trimTrajectories(tmp.traj[, YEAR:=c(t(as.matrix(panel.data[['Panel_Data']][, names.to.return, with=FALSE])))], lag.increment)
 				}

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -41,7 +41,7 @@ function(libname, pkgname) {
 
         # Define a friendly startup message
 		message_text <- paste0(
-		    magenta(bold("\uD83C\uDF89 SGP v", installed.version, sep="")), " - ", toOrdinal::toOrdinalDate("2026-7-23"), "\n",
+		    magenta(bold("\uD83C\uDF89 SGP v", installed.version, sep="")), " - ", toOrdinal::toOrdinalDate("2026-7-25"), "\n",
 			strrep("\u2501", 40), "\n",
     	    bold("\U1F4E6 CRAN: "), cran.version, "\n",
     	    bold("\U1F527 Dev: "), dev.version, "\n",

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -9,12 +9,12 @@ bibentry(
                     person(given = c("Yi"), family = "Shang")
                    ),
     year         = "2026",
-    note         = "R package version 2.3-1.1",
+    note         = "R package version 2.3-1.2",
     url          = "https://sgp.io",
     textVersion  = paste(
                     "Damian W. Betebenner, Adam R. Van Iwaarden, Benjamin Domingue and Yi Shang (2026).",
                     "SGP: Student Growth Percentiles & Percentile Growth Trajectories.",
-                    "(R package version 2.3-1.1)",
+                    "(R package version 2.3-1.2)",
                     "URL: https://sgp.io"
                   )
 )

--- a/man/SGP-package.Rd
+++ b/man/SGP-package.Rd
@@ -19,8 +19,8 @@ growth projections to be calculated across assessment transitions by equating th
 \tabular{ll}{
 Package: \tab SGP\cr
 Type: \tab Package\cr
-Version: \tab 2.3-1.1\cr
-Date: \tab 2026-7-23\cr
+Version: \tab 2.3-1.2\cr
+Date: \tab 2026-7-25\cr
 License: \tab GPL-3\cr
 LazyLoad: \tab yes\cr
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> The change alters projection trajectory trimming for character max-forward-progression year specs and can change outputs when the column was previously absent (NA-filled years). Scope is narrow but touches accountability-style target trajectories.
> 
> **Overview**
> **Patch release 2.3-1.2** (2026-7-25) with metadata and startup messaging aligned to the new version.
> 
> The functional change is in **`studentGrowthProjections`**: when character **`percentile.trajectory.values.max.forward.progression.years`** drives trajectory trimming (e.g. via target scale-score workflows), the code now **adds a missing `MOVE_UP_STAY_UP`-related column to `Panel_Data` as all `NA`** before joining those year fields into trajectories. That avoids failures when the max-forward-progression year variable is named for move-up/stay-up targets but was never created on the panel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8eba7be6c0cf0252005b0eab64e81f4e922f2c91. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->