### PR TITLE
Fixing up studentGrowthProjections issue

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,7 +11,7 @@ authors:
 - family-names: "Shang"
   given-names: "Yi"
 title: "SGP: Student Growth Percentiles & Percentile Growth Trajectories"
-version: 2.3-1.2
+version: 2.3-1.3
 doi: 10.5281/zenodo.10037891
-date-released: 2026-7-25
+date-released: 2026-7-27
 url: "https://sgp.io"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,7 +11,7 @@ authors:
 - family-names: "Shang"
   given-names: "Yi"
 title: "SGP: Student Growth Percentiles & Percentile Growth Trajectories"
-version: 2.3-1.3
+version: 2.3-1.4
 doi: 10.5281/zenodo.10037891
-date-released: 2026-7-27
+date-released: 2026-7-28
 url: "https://sgp.io"

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: SGP
 Type: Package
 Title: Student Growth Percentiles & Percentile Growth Trajectories
-Version: 2.3-1.3
-Date: 2026-7-27
+Version: 2.3-1.4
+Date: 2026-7-28
 Authors@R: c(person(given=c("Damian", "W."), family="Betebenner", email="dbetebenner@nciea.org", role=c("aut", "cre"), comment=c(ORCID = "0000-0003-0476-5599")),
 		person(given=c("Adam", "R."), family="Van Iwaarden", email="avaniwaarden@nciea.org", role="aut"),
 		person(given="Ben", family="Domingue", email="ben.domingue@gmail.com", role="aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: SGP
 Type: Package
 Title: Student Growth Percentiles & Percentile Growth Trajectories
-Version: 2.3-1.2
-Date: 2026-7-25
+Version: 2.3-1.3
+Date: 2026-7-27
 Authors@R: c(person(given=c("Damian", "W."), family="Betebenner", email="dbetebenner@nciea.org", role=c("aut", "cre"), comment=c(ORCID = "0000-0003-0476-5599")),
 		person(given=c("Adam", "R."), family="Van Iwaarden", email="avaniwaarden@nciea.org", role="aut"),
 		person(given="Ben", family="Domingue", email="ben.domingue@gmail.com", role="aut"),

--- a/R/studentGrowthPercentiles.R
+++ b/R/studentGrowthPercentiles.R
@@ -1965,7 +1965,8 @@ function(panel.data,         ## REQUIRED
                                       state = calculate.confidence.intervals[["state"]],
                                       variable = tmp.csem.variable,
                                       iterations = calculate.confidence.intervals[["simulation.iterations"]],
-                                      sgp.sim.seed = sgp.percentiles.set.seed),
+                                      sgp.sim.seed = sgp.percentiles.set.seed,
+                                      round.digits = calculate.confidence.intervals[["round.digits"]]),
                                 MARGIN = 2,
                                 FUN = function(x) .get_quantiles(tmp.predictions, x)
                             )

--- a/R/studentGrowthProjections.R
+++ b/R/studentGrowthProjections.R
@@ -379,12 +379,17 @@ function(panel.data,	## REQUIRED
 				tmp.traj <- percentile.trajectories[tmp.indices, 1L:(2L+tmp.num.years.forward-1L), with=FALSE][,ID:=rep(unique(percentile.trajectories, by='ID')[['ID']], each=length(percentile.trajectory.values))]
 				setkey(tmp.traj, ID)
 				if (is.character(percentile.trajectory.values.max.forward.progression.years)) {
-					if (!(grep("MOVE_UP_STAY_UP", percentile.trajectory.values.max.forward.progression.years, value=TRUE) %in% names(panel.data[['Panel_Data']]))) {
-						tmp.name <- grep("MOVE_UP_STAY_UP", percentile.trajectory.values.max.forward.progression.years, value=TRUE)
-						panel.data[['Panel_Data']][, (tmp.name):=NA]
+					missing.progression.names <- setdiff(percentile.trajectory.values.max.forward.progression.years, names(panel.data[['Panel_Data']]))
+					if (length(missing.progression.names) > 0L) {
+						panel.data[['Panel_Data']][, (missing.progression.names) := NA]
 					}
-					names.to.return <- intersect(names(panel.data[['Panel_Data']]), percentile.trajectory.values.max.forward.progression.years)
-					tmp.traj <- trimTrajectories(tmp.traj[, YEAR:=c(t(as.matrix(panel.data[['Panel_Data']][, names.to.return, with=FALSE])))], lag.increment)
+					tmp.traj <- trimTrajectories(tmp.traj[, YEAR:=c(t(as.matrix(panel.data[['Panel_Data']][, percentile.trajectory.values.max.forward.progression.years, with=FALSE])))], lag.increment)
+#					if (!(grep("MOVE_UP_STAY_UP", percentile.trajectory.values.max.forward.progression.years, value=TRUE) %in% names(panel.data[['Panel_Data']]))) {
+#						tmp.name <- grep("MOVE_UP_STAY_UP", percentile.trajectory.values.max.forward.progression.years, value=TRUE)
+#						panel.data[['Panel_Data']][, (tmp.name):=NA]
+#					}
+#					names.to.return <- intersect(names(panel.data[['Panel_Data']]), percentile.trajectory.values.max.forward.progression.years)
+#					tmp.traj <- trimTrajectories(tmp.traj[, YEAR:=c(t(as.matrix(panel.data[['Panel_Data']][, names.to.return, with=FALSE])))], lag.increment)
 				}
 
 				for (traj.names.iter in seq(tmp.num.years.forward)) {

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -41,7 +41,7 @@ function(libname, pkgname) {
 
         # Define a friendly startup message
 		message_text <- paste0(
-		    magenta(bold("\uD83C\uDF89 SGP v", installed.version, sep="")), " - ", toOrdinal::toOrdinalDate("2026-7-27"), "\n",
+		    magenta(bold("\uD83C\uDF89 SGP v", installed.version, sep="")), " - ", toOrdinal::toOrdinalDate("2026-7-28"), "\n",
 			strrep("\u2501", 40), "\n",
     	    bold("\U1F4E6 CRAN: "), cran.version, "\n",
     	    bold("\U1F527 Dev: "), dev.version, "\n",

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -41,7 +41,7 @@ function(libname, pkgname) {
 
         # Define a friendly startup message
 		message_text <- paste0(
-		    magenta(bold("\uD83C\uDF89 SGP v", installed.version, sep="")), " - ", toOrdinal::toOrdinalDate("2026-7-25"), "\n",
+		    magenta(bold("\uD83C\uDF89 SGP v", installed.version, sep="")), " - ", toOrdinal::toOrdinalDate("2026-7-27"), "\n",
 			strrep("\u2501", 40), "\n",
     	    bold("\U1F4E6 CRAN: "), cran.version, "\n",
     	    bold("\U1F527 Dev: "), dev.version, "\n",

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -9,12 +9,12 @@ bibentry(
                     person(given = c("Yi"), family = "Shang")
                    ),
     year         = "2026",
-    note         = "R package version 2.3-1.3",
+    note         = "R package version 2.3-1.4",
     url          = "https://sgp.io",
     textVersion  = paste(
                     "Damian W. Betebenner, Adam R. Van Iwaarden, Benjamin Domingue and Yi Shang (2026).",
                     "SGP: Student Growth Percentiles & Percentile Growth Trajectories.",
-                    "(R package version 2.3-1.3)",
+                    "(R package version 2.3-1.4)",
                     "URL: https://sgp.io"
                   )
 )

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -9,12 +9,12 @@ bibentry(
                     person(given = c("Yi"), family = "Shang")
                    ),
     year         = "2026",
-    note         = "R package version 2.3-1.2",
+    note         = "R package version 2.3-1.3",
     url          = "https://sgp.io",
     textVersion  = paste(
                     "Damian W. Betebenner, Adam R. Van Iwaarden, Benjamin Domingue and Yi Shang (2026).",
                     "SGP: Student Growth Percentiles & Percentile Growth Trajectories.",
-                    "(R package version 2.3-1.2)",
+                    "(R package version 2.3-1.3)",
                     "URL: https://sgp.io"
                   )
 )

--- a/man/SGP-package.Rd
+++ b/man/SGP-package.Rd
@@ -19,8 +19,8 @@ growth projections to be calculated across assessment transitions by equating th
 \tabular{ll}{
 Package: \tab SGP\cr
 Type: \tab Package\cr
-Version: \tab 2.3-1.3\cr
-Date: \tab 2026-7-27\cr
+Version: \tab 2.3-1.4\cr
+Date: \tab 2026-7-28\cr
 License: \tab GPL-3\cr
 LazyLoad: \tab yes\cr
 }

--- a/man/SGP-package.Rd
+++ b/man/SGP-package.Rd
@@ -19,8 +19,8 @@ growth projections to be calculated across assessment transitions by equating th
 \tabular{ll}{
 Package: \tab SGP\cr
 Type: \tab Package\cr
-Version: \tab 2.3-1.2\cr
-Date: \tab 2026-7-25\cr
+Version: \tab 2.3-1.3\cr
+Date: \tab 2026-7-27\cr
 License: \tab GPL-3\cr
 LazyLoad: \tab yes\cr
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Projection target trajectories can change when multiple max-forward-progression year columns are used; CSEM confidence-interval simulations may round differently when state round.digits is set.
> 
> **Overview**
> Releases **SGP 2.3-1.4** (2026-7-28) with metadata and startup message updates only in packaging/citation files.
> 
> **`studentGrowthProjections`** fixes how **`percentile.trajectory.values.max.forward.progression.years`** is applied when it is a **vector of panel column names** (e.g. multi-year MOVE_UP_STAY_UP style fields). Missing columns are added as `NA` for every requested name, and **`trimTrajectories`** now always binds the full year matrix from that argument instead of intersecting with existing names (which could drop columns or mishandle non–MOVE_UP_STAY_UP names).
> 
> **`studentGrowthPercentiles`** passes **`calculate.confidence.intervals[["round.digits"]]`** into **`csemScoreSimulator`** so CSEM-based simulated SGPs respect state **`SGP_Configuration`** rounding during confidence-interval simulation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79f5c05f246ab47e1a81de5b53d68126caeb37b6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->