### PR TITLE
Bumping version number

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,7 +11,7 @@ authors:
 - family-names: "Shang"
   given-names: "Yi"
 title: "SGP: Student Growth Percentiles & Percentile Growth Trajectories"
-version: 2.3-1.6
+version: 2.3-1.7
 doi: 10.5281/zenodo.10037891
-date-released: 2026-8-3
+date-released: 2026-8-4
 url: "https://sgp.io"

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: SGP
 Type: Package
 Title: Student Growth Percentiles & Percentile Growth Trajectories
-Version: 2.3-1.6
-Date: 2026-8-3
+Version: 2.3-1.7
+Date: 2026-8-4
 Authors@R: c(person(given=c("Damian", "W."), family="Betebenner", email="dbetebenner@nciea.org", role=c("aut", "cre"), comment=c(ORCID = "0000-0003-0476-5599")),
 		person(given=c("Adam", "R."), family="Van Iwaarden", email="avaniwaarden@nciea.org", role="aut"),
 		person(given="Ben", family="Domingue", email="ben.domingue@gmail.com", role="aut"),

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -41,7 +41,7 @@ function(libname, pkgname) {
 
         # Define a friendly startup message
 		message_text <- paste0(
-		    magenta(bold("\uD83C\uDF89 SGP v", installed.version, sep="")), " - ", toOrdinal::toOrdinalDate("2026-8-3"), "\n",
+		    magenta(bold("\uD83C\uDF89 SGP v", installed.version, sep="")), " - ", toOrdinal::toOrdinalDate("2026-8-4"), "\n",
 			strrep("\u2501", 40), "\n",
     	    bold("\U1F4E6 CRAN: "), cran.version, "\n",
     	    bold("\U1F527 Dev: "), dev.version, "\n",

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ SGP
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.6471237.svg)](https://doi.org/10.5281/zenodo.6471237)
 [![R-CMD-check](https://github.com/CenterForAssessment/SGP/workflows/R-CMD-check/badge.svg)](https://github.com/CenterForAssessment/SGP/actions)
 [![CRAN_Status_Badge](https://www.r-pkg.org/badges/version/SGP)](https://cran.r-project.org/package=SGP)
-[![Development Version](https://img.shields.io/badge/devel-2.3--0.0-brightgreen.svg)](https://github.com/CenterForAssessment/SGP)
+[![Development Version](https://img.shields.io/badge/devel-2.3--1.7-brightgreen.svg)](https://github.com/CenterForAssessment/SGP)
 [![Rstudio mirror downloads](https://cranlogs.r-pkg.org/badges/grand-total/SGP)](https://github.com/metacran/cranlogs.app)
 [![License](https://img.shields.io/badge/license-GPL%203-brightgreen.svg?style=flat)](https://github.com/CenterForAssessment/SGP/blob/master/LICENSE.md)
 

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -9,12 +9,12 @@ bibentry(
                     person(given = c("Yi"), family = "Shang")
                    ),
     year         = "2026",
-    note         = "R package version 2.3-1.6",
+    note         = "R package version 2.3-1.7",
     url          = "https://sgp.io",
     textVersion  = paste(
                     "Damian W. Betebenner, Adam R. Van Iwaarden, Benjamin Domingue and Yi Shang (2026).",
                     "SGP: Student Growth Percentiles & Percentile Growth Trajectories.",
-                    "(R package version 2.3-1.6)",
+                    "(R package version 2.3-1.7)",
                     "URL: https://sgp.io"
                   )
 )

--- a/man/SGP-package.Rd
+++ b/man/SGP-package.Rd
@@ -19,8 +19,8 @@ growth projections to be calculated across assessment transitions by equating th
 \tabular{ll}{
 Package: \tab SGP\cr
 Type: \tab Package\cr
-Version: \tab 2.3-1.6\cr
-Date: \tab 2026-8-3\cr
+Version: \tab 2.3-1.7\cr
+Date: \tab 2026-8-4\cr
 License: \tab GPL-3\cr
 LazyLoad: \tab yes\cr
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation and metadata-only release bump with no functional or dependency changes.
> 
> **Overview**
> Releases **SGP v2.3-1.7** by updating version and **2026-8-4** release date consistently across package metadata.
> 
> **`DESCRIPTION`** and **`CITATION.cff`** carry the new version and date. **`inst/CITATION`**, **`man/SGP-package.Rd`**, and the README development badge are aligned for citations and docs. The interactive startup message in **`R/zzz.R`** now shows the updated release date via `toOrdinal::toOrdinalDate("2026-8-4")`.
> 
> No changes to analysis logic, APIs, or dependencies—metadata and user-facing version strings only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b34a08322f1c2df8f7d52d6e2f23b381fb6a67ea. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->